### PR TITLE
use the fedora-minimal base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 LABEL org.opencontainers.image.title="memcached" \
       org.opencontainers.image.description="memcached in a container, suitable for running on OpenShift" \
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.title="memcached" \
 EXPOSE 11211
 CMD  ["/usr/local/bin/start-memcached.sh"]
 
-RUN dnf -y install memcached && dnf clean all
+RUN microdnf -y install memcached && microdnf clean all
 COPY start-memcached.sh /usr/local/bin/start-memcached.sh
 RUN chmod 755 /usr/local/bin/start-memcached.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,19 @@
 FROM registry.fedoraproject.org/fedora-minimal:33
 
-LABEL org.opencontainers.image.title="memcached" \
+ENV MEMCACHED_VERSION="1.6.6"
+
+LABEL name="memcached" \
+      version="$MEMCACHED_VERSION" \
+      vendor="Red Hat EXD Software Production" \
+      license="BSD-3-Clause" \
+      org.opencontainers.image.title="memcached" \
+      org.opencontainers.image.version="$MEMCACHED_VERSION" \
       org.opencontainers.image.description="memcached in a container, suitable for running on OpenShift" \
       org.opencontainers.image.vendor="Red Hat EXD Software Production" \
       org.opencontainers.image.authors="C3I Guild <exd-guild-c3i@redhat.com>" \
       org.opencontainers.image.licenses="BSD-3-Clause" \
       org.opencontainers.image.url="https://github.com/release-engineering/memcached-container" \
+      org.opencontainers.image.source="https://github.com/release-engineering/memcached-container" \
       org.opencontainers.image.documentation="https://github.com/release-engineering/memcached-container" \
       distribution-scope="public"
 

--- a/start-memcached.sh
+++ b/start-memcached.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 if [ -n "$MEMCACHED_CACHE_SIZE" ]; then
     MEMCACHED_ARGS+=" -m $MEMCACHED_CACHE_SIZE"
 fi


### PR DESCRIPTION
Also, retrieve it directly from the official Fedora registry to avoid request throttling from docker.io, add some additional labels, and be more verbose on service startup.